### PR TITLE
Fix GitHub Pages Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-This project is hosted on GitHub Pages in this Link: (https://ashish-avs.github.io/Time-Table/). 
+This project is hosted on GitHub Pages in this Link: (https://ashish-avs.github.io/TimeTable/).
 
 Feel free to suggest/contribute to this project :)
 


### PR DESCRIPTION
Hello!
I found the GItHub Pages link in the README to be a 404.
I've fixed the URL of the link.